### PR TITLE
Refactor manager factories

### DIFF
--- a/implementation/src/main/java/factories/ManagerFactory.java
+++ b/implementation/src/main/java/factories/ManagerFactory.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Constructor;
 
 public enum ManagerFactory {
     ALBUM("AlbumManagerImpl"),
-    COVER_IMAGE("CoverImageManagerImpl"),
+    //COVER_IMAGE("CoverImageManagerImpl"),
     ARTIST("ArtistManagerImpl");
 
     private IManager manager;

--- a/implementation/src/main/java/factories/ManagerFactory.java
+++ b/implementation/src/main/java/factories/ManagerFactory.java
@@ -1,0 +1,33 @@
+package factories;
+
+import repository.core.IAlbumManager;
+import repository.core.IArtistManager;
+import repository.core.ICoverImageManager;
+import repository.core.IManager;
+import utilities.ConfigReader;
+
+import java.lang.reflect.Constructor;
+
+public enum ManagerFactory {
+    ALBUM("AlbumManagerImpl"),
+    COVER_IMAGE("CoverImageManagerImpl"),
+    ARTIST("ArtistManagerImpl");
+
+    private IManager manager;
+
+    ManagerFactory(String configKey) {
+        try {
+            Class<?> cl = Class.forName(ConfigReader.getConfigFileKey(ConfigReader.CONFIG_FILE, configKey));
+            Constructor<?> cons = cl.getConstructor();
+            manager = (IManager) cons.newInstance();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public IManager getManager(){
+        return manager;
+    }
+
+}

--- a/implementation/src/main/java/utilities/ConfigReader.java
+++ b/implementation/src/main/java/utilities/ConfigReader.java
@@ -9,6 +9,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 public class ConfigReader {
+    public static String CONFIG_FILE = "config.json";
+
     public static String getConfigFileKey(String file, String key) throws IOException, ParseException  {
         InputStream inputStream = ConfigReader.class.getClassLoader().getResourceAsStream(file); // Get resource
         Object obj = new JSONParser().parse(new InputStreamReader(inputStream)); // Read file

--- a/source/src/main/java/repository/core/CoverImage.java
+++ b/source/src/main/java/repository/core/CoverImage.java
@@ -1,0 +1,17 @@
+package repository.core;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.sql.Blob;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class CoverImage {
+    @XmlElement
+    private String coverImageId;
+    @XmlElement
+    private String mimeType;
+    private Blob blob; //blob should not be serialized
+}

--- a/source/src/main/java/repository/core/IAlbumCoverManager.java
+++ b/source/src/main/java/repository/core/IAlbumCoverManager.java
@@ -1,0 +1,7 @@
+package repository.core;
+
+public interface IAlbumCoverManager {
+    CoverImage getCoverImage();
+    boolean updateCoverImage();
+    boolean deleteCoverImage();
+}

--- a/source/src/main/java/repository/core/IAlbumManager.java
+++ b/source/src/main/java/repository/core/IAlbumManager.java
@@ -2,7 +2,7 @@ package repository.core;
 
 import java.util.ArrayList;
 
-public interface IAlbumManager {
+public interface IAlbumManager extends IManager{
     ArrayList<Album> listAlbum();
     Album getAlbum(String isrc);
     boolean addAlbum(Album album);

--- a/source/src/main/java/repository/core/IArtistManager.java
+++ b/source/src/main/java/repository/core/IArtistManager.java
@@ -2,7 +2,7 @@ package repository.core;
 
 import java.util.ArrayList;
 
-public interface IArtistManager {
+public interface IArtistManager extends IManager{
     /**
     ArrayList<Artist> listArtist();
     Artist getArtist(String nickname);

--- a/source/src/main/java/repository/core/ICoverImageManager.java
+++ b/source/src/main/java/repository/core/ICoverImageManager.java
@@ -1,6 +1,6 @@
 package repository.core;
 
-public interface IAlbumCoverManager {
+public interface ICoverImageManager extends IManager {
     CoverImage getCoverImage();
     boolean updateCoverImage();
     boolean deleteCoverImage();

--- a/source/src/main/java/repository/core/IManager.java
+++ b/source/src/main/java/repository/core/IManager.java
@@ -1,0 +1,4 @@
+package repository.core;
+
+public interface IManager {
+}


### PR DESCRIPTION
I refactored and merged 3 manager factories together as an enumerator. The way that the factory would work now is you call FactoryManager.<ManagerType>.getManager(). Since the returned manager is of IManagerType, you need to cast it to the correct sub-manager class before using. 