### PR TITLE
Album CRUD layers exception handling (excluding CoverImage)

### DIFF
--- a/album-service/src/main/java/com/example/rest/AlbumREST.java
+++ b/album-service/src/main/java/com/example/rest/AlbumREST.java
@@ -39,12 +39,13 @@ public class AlbumREST {
         try {
             Album album = albumManager.getAlbum(isrc);
 
+            if(album == null)
+                return Response.status(Response.Status.FORBIDDEN)
+                        .entity("No album with an ISRC of " + isrc)
+                        .build();
+
             return Response.status(Response.Status.OK)
                     .entity(album)
-                    .build();
-        } catch(RepException re) {
-            return Response.status(Response.Status.FORBIDDEN)
-                    .entity(re.getMessage())
                     .build();
         } catch(Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -63,7 +64,7 @@ public class AlbumREST {
 
             if(!success) {
                 return Response.status(Response.Status.FORBIDDEN)
-                        .entity(String.format("Failed to add album: album with an ISRC of %s already exists", album.getIsrc()))
+                        .entity(String.format("Failed to add album"))
                         .build();
             }
 
@@ -76,8 +77,7 @@ public class AlbumREST {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(re.getMessage())
                     .build();
-        }
-        catch(Exception e) {
+        } catch(Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity("An error occurred while trying to add the album")
                     .build();
@@ -119,18 +119,16 @@ public class AlbumREST {
     @Path("{isrc}")
     public Response deleteAlbum(@PathParam("isrc") String isrc) {
         try {
-            boolean success = albumManager.deleteAlbum(isrc);
-
-            if(!success) {
-                return Response.status(Response.Status.FORBIDDEN)
-                        .entity("Failed to delete album with an ISRC of " + isrc)
-                        .build();
-            }
+            albumManager.deleteAlbum(isrc);
 
             logManager.addLog(new Log(LocalDateTime.now(), Log.ChangeType.DELETE, isrc));
 
             return Response.status(Response.Status.OK)
                     .entity("Successfully deleted album")
+                    .build();
+        } catch(RepException re) {
+            return Response.status(Response.Status.FORBIDDEN)
+                    .entity(re.getMessage())
                     .build();
         } catch(Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/implementation/src/main/java/AlbumManagerInDB.java
+++ b/implementation/src/main/java/AlbumManagerInDB.java
@@ -3,23 +3,19 @@ import repository.core.Album;
 import repository.core.IAlbumManager;
 import repository.core.RepException;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 
 public class AlbumManagerInDB implements IAlbumManager {
-    public ArrayList<Album> listAlbum() {
+    public ArrayList<Album> listAlbum() throws SQLException {
         return AlbumDAO.getAllAlbums();
     }
 
-    public Album getAlbum(String isrc) throws RepException {
-        Album album = AlbumDAO.getAlbumDatabase(isrc);
-
-        if(album == null)
-            throw new RepException("No album with an ISRC of " + isrc);
-
-        return album;
+    public Album getAlbum(String isrc) throws SQLException {
+        return AlbumDAO.getAlbumDatabase(isrc);
     }
 
-    public boolean addAlbum(Album album) throws RepException {
+    public boolean addAlbum(Album album) throws SQLException, RepException {
         if(album.getIsrc() == null || album.getIsrc().isEmpty() ||
                 album.getTitle() == null || album.getTitle().isEmpty() ||
                 album.getArtist() == null ||
@@ -29,12 +25,15 @@ public class AlbumManagerInDB implements IAlbumManager {
             throw new RepException("Failed to add album: missing required fields");
         else if(album.getReleaseYear() <= 0)
             throw new RepException("Failed to add album: invalid releaseYear");
+        else if(getAlbum(album.getIsrc()) != null)
+            throw new RepException(String.format("Failed to add album: album with an ISRC of %s already exists", album.getIsrc()));
+
 
         return AlbumDAO.insertAlbum(album.getIsrc(), album.getTitle(), album.getContentDesc(),
                 album.getReleaseYear(), album.getArtist().getFirstname(), album.getArtist().getLastname());
     }
 
-    public boolean updateAlbum(Album album) throws RepException {
+    public boolean updateAlbum(Album album) throws SQLException, RepException {
         if(album.getTitle() == null || album.getTitle().isEmpty() ||
                 album.getArtist() == null ||
                 album.getArtist().getFirstname() == null || album.getArtist().getFirstname().isEmpty() ||
@@ -48,7 +47,12 @@ public class AlbumManagerInDB implements IAlbumManager {
                 album.getReleaseYear(), album.getArtist().getFirstname(), album.getArtist().getLastname());
     }
 
-    public boolean deleteAlbum(String isrc) {
-        return AlbumDAO.deleteAlbum(isrc);
+    public boolean deleteAlbum(String isrc) throws SQLException, RepException {
+        boolean success = AlbumDAO.deleteAlbum(isrc);
+
+        if(!success)
+            throw new RepException("Failed to delete album with an ISRC of " + isrc);
+
+        return true; // Always true anyway
     }
 }

--- a/implementation/src/main/java/database/dao/AlbumDAO.java
+++ b/implementation/src/main/java/database/dao/AlbumDAO.java
@@ -11,21 +11,21 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 
 public class AlbumDAO {
-    public static Album getAlbumDatabase(String isrc){
+    public static Album getAlbumDatabase(String isrc) throws SQLException{
         Album album = null;
-        try {
-            Connection conn = DBConnection.getConnection();
-            String query = "SELECT * FROM Albums WHERE isrc =?";
+        Connection conn = DBConnection.getConnection();
+        String query = "SELECT * FROM Albums WHERE isrc =?";
 
-            PreparedStatement stmt = conn.prepareStatement(query);
-            stmt.setString(1, isrc);
-            ResultSet rs = stmt.executeQuery();
-            if (rs.next())
-                album = mapResultSetToAlbum(rs);
-        } catch (Exception e) {
-            System.err.println("There was an error retrieving specific album from database.");
-            System.err.println(e.getMessage());
-        }
+        PreparedStatement stmt = conn.prepareStatement(query);
+        stmt.setString(1, isrc);
+        ResultSet rs = stmt.executeQuery();
+
+        if (rs.next())
+            album = mapResultSetToAlbum(rs);
+//        } catch (Exception e) {
+//            System.err.println("There was an error retrieving specific album from database.");
+//            System.err.println(e.getMessage());
+//        }
         return album;
     }
     private static Album mapResultSetToAlbum(ResultSet rs) throws SQLException {
@@ -47,103 +47,93 @@ public class AlbumDAO {
 
         return album;
     }
-    public static ArrayList<Album> getAllAlbums() {
+    public static ArrayList<Album> getAllAlbums() throws SQLException {
         // Get query result
         String sql = "SELECT * FROM Albums ORDER BY title ASC, isrc ASC";
 
         return getAllAlbumsHelper(sql);
     }
 
-    private static ArrayList<Album> getAllAlbumsHelper(String sql) {
+    private static ArrayList<Album> getAllAlbumsHelper(String sql) throws SQLException {
         ArrayList<Album> albums = new ArrayList<>();
+        Connection conn = DBConnection.getConnection();
 
-        try {
-            Connection conn = DBConnection.getConnection();
+        // Get query result
+        PreparedStatement ps = conn.prepareStatement(sql);
+        ResultSet rs = ps.executeQuery();
 
-            // Get query result
-            PreparedStatement ps = conn.prepareStatement(sql);
-            ResultSet rs = ps.executeQuery();
-
-            // For each element of query result
-            while(rs.next())
-                albums.add(mapResultSetToAlbum(rs));
-        } catch(Exception e) {
-            e.printStackTrace();
-        } finally {
-            DBConnection.closeConnection();
-        }
+        // For each element of query result
+        while(rs.next())
+            albums.add(mapResultSetToAlbum(rs));
+        DBConnection.closeConnection();
 
         return albums;
     }
 
-    public static boolean insertAlbum(String isrc, String title, String contentDesc, int releasedYear, String firstName, String lastName) {
+    public static boolean insertAlbum(String isrc, String title, String contentDesc, int releasedYear, String firstName, String lastName) throws SQLException {
         boolean success = false;
-        try {
-            Connection conn = DBConnection.getConnection();
+        Connection conn = DBConnection.getConnection();
+        String query = "INSERT INTO Albums (isrc, title, contentDesc, releasedYear, artistFirstName, artistLastName)" + " values (?,?,?,?,?,?)";
 
-            String query = "INSERT INTO Albums (isrc, title, contentDesc, releasedYear, artistFirstName, artistLastName)" + " values (?,?,?,?,?,?)";
-            PreparedStatement stmt = conn.prepareStatement(query);
+        PreparedStatement stmt = conn.prepareStatement(query);
+        stmt.setString(1, isrc);
+        stmt.setString(2, title);
+        stmt.setString(3, contentDesc);
+        stmt.setInt(4, releasedYear);
+        stmt.setString(5, firstName);
+        stmt.setString(6, lastName);
+        int row = stmt.executeUpdate();
 
-            stmt.setString(1, isrc);
-            stmt.setString(2, title);
-            stmt.setString(3, contentDesc);
-            stmt.setInt(4, releasedYear);
-            stmt.setString(5, firstName);
-            stmt.setString(6, lastName);
-            int row = stmt.executeUpdate();
+        if (row > 0)
+            success = true;
 
-            if (row > 0)
-                success = true;
-
-        } catch (Exception e) {
-            System.err.println("There was an error creating a new album in database.");
-            System.err.println(e.getMessage());
-        }
+//        } catch (Exception e) {
+//            System.err.println("There was an error creating a new album in database.");
+//            System.err.println(e.getMessage());
+//        }
         return success;
     }
 
-    public static boolean updateAlbum(String isrc, String title, String contentDesc, int releasedYear, String firstName, String lastName) {
+    public static boolean updateAlbum(String isrc, String title, String contentDesc, int releasedYear, String firstName, String lastName) throws SQLException {
         boolean success = false;
-        try {
-            Connection conn = DBConnection.getConnection();
-            String query = "UPDATE Albums SET title = ?, contentDesc = ?, releasedYear = ?, artistFirstName = ?, artistLastName = ? WHERE isrc = ?";
+        Connection conn = DBConnection.getConnection();
+        String query = "UPDATE Albums SET title = ?, contentDesc = ?, releasedYear = ?, artistFirstName = ?, artistLastName = ? WHERE isrc = ?";
 
-            PreparedStatement stmt = conn.prepareStatement(query);
-            stmt.setString(1, title);
-            stmt.setString(2, contentDesc);
-            stmt.setInt(3, releasedYear);
-            stmt.setString(4, firstName);
-            stmt.setString(5, lastName);
-            stmt.setString(6, isrc);
-            int row = stmt.executeUpdate();
+        PreparedStatement stmt = conn.prepareStatement(query);
+        stmt.setString(1, title);
+        stmt.setString(2, contentDesc);
+        stmt.setInt(3, releasedYear);
+        stmt.setString(4, firstName);
+        stmt.setString(5, lastName);
+        stmt.setString(6, isrc);
+        int row = stmt.executeUpdate();
 
-            if (row > 0)
-                success = true;
+        if (row > 0)
+            success = true;
 
-        } catch (Exception e) {
-            System.err.println("There was an error updating album in database.");
-            System.err.println(e.getMessage());
-        }
+//        } catch (Exception e) {
+//            System.err.println("There was an error updating album in database.");
+//            System.err.println(e.getMessage());
+//        }
         return success;
     }
 
-    public static boolean deleteAlbum(String isrc) {
+    public static boolean deleteAlbum(String isrc) throws SQLException {
         boolean success = false;
-        try {
-            Connection conn = DBConnection.getConnection();
-            String query = "DELETE FROM Albums WHERE isrc = ?";
+        Connection conn = DBConnection.getConnection();
+        String query = "DELETE FROM Albums WHERE isrc = ?";
 
-            PreparedStatement stmt = conn.prepareStatement(query);
-            stmt.setString(1, isrc);
-            int row = stmt.executeUpdate();
+        PreparedStatement stmt = conn.prepareStatement(query);
+        stmt.setString(1, isrc);
+        int row = stmt.executeUpdate();
 
-            if (row > 0)
-                success = true;
+        if (row > 0)
+            success = true;
 
-        } catch (Exception e) {
-            System.err.println("There was an error deleting the album in database.");
-            System.err.println(e.getMessage());
-        }
+//        } catch (Exception e) {
+//            System.err.println("There was an error deleting the album in database.");
+//            System.err.println(e.getMessage());
+//        }
         return success;
     }
 }

--- a/implementation/src/main/java/impl/AlbumManagerInDB.java
+++ b/implementation/src/main/java/impl/AlbumManagerInDB.java
@@ -1,3 +1,5 @@
+package impl;
+
 import database.dao.AlbumDAO;
 import repository.core.Album;
 import repository.core.IAlbumManager;

--- a/implementation/src/main/resources/config.json
+++ b/implementation/src/main/resources/config.json
@@ -1,5 +1,5 @@
 {
   "ArtistManagerImpl": "ArtistManagerInMemory",
-  "AlbumManagerImpl": "AlbumManagerInDB",
+  "AlbumManagerImpl": "impl.AlbumManagerInDB",
   "LogManagerImpl": "LogManagerInDB"
 }

--- a/source/src/main/java/repository/core/IAlbumManager.java
+++ b/source/src/main/java/repository/core/IAlbumManager.java
@@ -1,11 +1,12 @@
 package repository.core;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 
 public interface IAlbumManager extends IManager{
-    ArrayList<Album> listAlbum();
-    Album getAlbum(String isrc) throws RepException;
-    boolean addAlbum(Album album) throws RepException;
-    boolean updateAlbum(Album album) throws RepException;
-    boolean deleteAlbum(String isrc);
+    ArrayList<Album> listAlbum() throws SQLException;
+    Album getAlbum(String isrc) throws SQLException, RepException;
+    boolean addAlbum(Album album) throws SQLException, RepException;
+    boolean updateAlbum(Album album) throws SQLException, RepException;
+    boolean deleteAlbum(String isrc) throws SQLException, RepException;
 }


### PR DESCRIPTION
Meant to fix exception handling in Album CRUD layers (excluding CoverImage) so that it follows the assignment requirements
<br />

<ins>Main Changes</ins>
- Made `AlbumDAO` and `AlbumManagerInDB` throw exceptions to `AlbumREST` where the exception is then handled
- Changed throws for `RepException` to ADD/UPDATE/DELETE in `AlbumManagerInDB` only
- Also moved `AlbumREST` to the `impl` package
<br />

**PS**: kept getting errors when I tried to move the logging in `AlbumREST` to `AlbumManagerInDB` so I didn't do that yet